### PR TITLE
add phony targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,27 +2,38 @@
 CC = clang
 DBG = lldb
 
+# PHONY targets override some default beahviours in makefiles
+# more on https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html
+
+.PHONY: build-main
 build-main: build-dir
 	$(CC) -Wall -O0 -g -o build/main src/main.c
 
+.PHONY: check
 check:
 	@which $(CC) > /dev/null && echo "SUCCESS: $(CC) is installed" || echo "ERROR: $(CC) not found, please install clang"
 	@which $(DBG) > /dev/null && echo "SUCCESS: $(DBG) is installed" || echo "ERROR: $(DBG) not found, please install lldb"
 
+.PHONY: build-dir
 build-dir:
 	if [ ! -d build ]; then mkdir build; fi
 
+.PHONY: build-test
 build-test: build-dir
 	$(CC) -Wall -O0 -g -o build/test src/test.c
 
+.PHONY: run
 run: build-main
 	./build/main
 
+.PHONY: build-test
 test: build-test
 	./build/test
 
+.PHONY: debug
 debug: build-main
 	$(DBG) ./build/main
 
+.PHONY: debug-test
 debug-test: build-test
 	$(DBG) ./build/test


### PR DESCRIPTION
although a toy project I would suggest adding phony targets to avoid some default and unwanted behaviours when file updates happen and make won't run